### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Welcome to the Fetcher MCP GitHub repository! This repository hosts the MCP server for fetching web page content using the Playwright headless browser.
 
+<a href="https://glama.ai/mcp/servers/@everford/fetcher-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@everford/fetcher-mcp/badge" alt="Fetcher MCP server" />
+</a>
+
 ## 🧠 About
 
 The Fetcher MCP is designed to leverage artificial intelligence capabilities to efficiently retrieve web page content. By utilizing the Playwright headless browser, this server can navigate through web pages and extract desired information with ease.


### PR DESCRIPTION
This PR adds a badge for the [Fetcher MCP](https://glama.ai/mcp/servers/@everford/fetcher-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@everford/fetcher-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@everford/fetcher-mcp/badge" alt="Fetcher MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.